### PR TITLE
Fix import directives

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var postcss = require('postcss');
+var gonzales = require('gonzales');
 
 var ESCAPED_DOT = ' ___LOCAL_SCOPE__ESCAPED_DOT___ ';
 
@@ -24,6 +25,9 @@ function transformSelector(options, rule, selector) {
       }
     }
   }
+
+  var ast = gonzales.srcToCSSP( selector + " {}" );
+  console.log( gonzales.csspToTree(ast))
 
   return selector
     .replace(/\:global\((.*?)\)/g, escapeDots)

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/css-modules/postcss-modules-local-by-default.git"
   },
   "dependencies": {
+    "gonzales": "^1.0.7",
     "postcss": "^4.1.5"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -110,6 +110,16 @@ var tests = [
     expected: ':local(.foo):after {}'
   },
   {
+    should: 'ignore :export statemtents',
+    input: ':export { foo: __foo; }',
+    expected: ':export { foo: __foo; }'
+  },
+  {
+    should: 'ignore :import statemtents',
+    input: ':import("~/lol.css") { foo: __foo; }',
+    expected: ':import("~/lol.css") { foo: __foo; }'
+  },
+  {
     should: 'not reject non-global element selectors when lint mode is not enabled',
     input: 'input {}',
     expected: 'input {}'


### PR DESCRIPTION
The `.` in a path is getting picked up as a class. Export statements seem fine.
