### PR TITLE
Fix for case where no options are passed or options is not an object, causing the plugin to crash.

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,6 +189,7 @@ function localizeDecl(decl, context) {
 }
 
 module.exports = postcss.plugin('postcss-modules-local-by-default', function (options) {
+  if (typeof options !== 'object') {options = {};} // If options is undefined or not an object the plugin fails
   if(options && options.mode) {
     if(options.mode !== "global" && options.mode !== "local" && options.mode !== "pure") {
       throw new Error("options.mode must be either 'global', 'local' or 'pure' (default 'local')");

--- a/index.js
+++ b/index.js
@@ -189,7 +189,9 @@ function localizeDecl(decl, context) {
 }
 
 module.exports = postcss.plugin('postcss-modules-local-by-default', function (options) {
-  if (typeof options !== 'object') {options = {};} // If options is undefined or not an object the plugin fails
+  if (typeof options !== 'object') {
+    options = {}; // If options is undefined or not an object the plugin fails
+  }
   if(options && options.mode) {
     if(options.mode !== "global" && options.mode !== "local" && options.mode !== "pure") {
       throw new Error("options.mode must be either 'global', 'local' or 'pure' (default 'local')");


### PR DESCRIPTION
The plugin was throwing because it could not read `rewriteUrl of undefined`. This fixes that by making sure `options` is always an object (and by extension `context.options` is an object). 

The error was on this line. https://github.com/frederickfogerty/postcss-modules-local-by-default/blob/b23baadf41b29a72e14fc61fc60a41723fbcf27a/index.js#L158
