### PR TITLE
Fix localizeName regular expression for animations

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,7 +175,7 @@ function localizeDeclValue(valueNode, context) {
 
 function localizeDecl(decl, context) {
   var valuesNode = Tokenizer.parseValues(decl.value);
-  var localizeName = /animation(-name)?/.test(decl.prop);
+  var localizeName = /animation(-name)?$/.test(decl.prop);
   var newValuesNode = Object.create(valuesNode);
   newValuesNode.nodes = valuesNode.nodes.map(function(valueNode) {
     var subContext = {


### PR DESCRIPTION
Fix regex from incorrectly matching the following CSS properties:
- `animation-duration`
- `animation-timing-function`
- `animation-delay`
- `animation-iteration-count`
- `animation-direction`
- `animation-fill-mode`
- `animation-play-state`

To only match:
- `animation`
- `animation-name`
