### PR TITLE
fix: allow for "no options" case

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ function localizeDeclNode(node, context) {
       }
       break;
     case "url":
-      if(context.options.rewriteUrl) {
+      if(context.options && context.options.rewriteUrl) {
         newNode = Object.create(node);
         newNode.url = context.options.rewriteUrl(context.global, node.url);
         return newNode;


### PR DESCRIPTION
Without this, we can get a "TypeError: Cannot read property 'rewriteUrl' of undefined" when no options are passed.
