### PR TITLE
Bugfix - crash on no opts and url()

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,7 +215,7 @@ module.exports = postcss.plugin('postcss-modules-local-by-default', function (op
         atrule.nodes.forEach(function(decl) {
           if(decl.type === "decl") {
             localizeDecl(decl, {
-              options: options,
+              options: options || {},
               global: globalMode
             });
           }


### PR DESCRIPTION
When loading without options = {} (e.g. `require('postcss-modules-local-by-default')()`) app will crash on url()-containing value (e.g. `background-image: url(...)`) due to `if (context.options.rewriteUrl)` -> context.options is undefined.
