### PR TITLE
Fix a bug that sometimes crashes on `url(...)`

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ function localizeDeclNode(node, context) {
       }
       break;
     case "url":
-      if(context.options.rewriteUrl) {
+      if(context.options && context.options.rewriteUrl) {
         newNode = Object.create(node);
         newNode.url = context.options.rewriteUrl(context.global, node.url);
         return newNode;

--- a/test.js
+++ b/test.js
@@ -393,7 +393,7 @@ test(name, function (t) {
     t.plan(tests.length);
 
     tests.forEach(function (testCase) {
-        var options = testCase.options || {};
+        var options = testCase.options;
         if(testCase.error) {
           t.throws(function() {
             process(testCase.input, options);


### PR DESCRIPTION
Prevents `context.options` being used when it is undefined. 

I also updated the test case which had previously masked this bug (as it was always defining `context.options`).

Related to https://github.com/css-modules/css-modules-loader-core/issues/30
