### PR TITLE
Don't crash on rules without child nodes

### DIFF
--- a/index.js
+++ b/index.js
@@ -264,9 +264,12 @@ module.exports = postcss.plugin('postcss-modules-local-by-default', function (op
         throw rule.error('Selector "' + Tokenizer.stringify(selector) + '" is not pure ' +
           '(pure selectors must contain at least one local class or id)');
       }
-      rule.nodes.forEach(function(decl) {
-        localizeDecl(decl, context);
-      });
+      // Less-syntax mixins parse as rules with no nodes
+      if (rule.nodes) {
+        rule.nodes.forEach(function(decl) {
+          localizeDecl(decl, context);
+        });
+      }
       rule.selector = Tokenizer.stringify(newSelector);
     });
   };

--- a/test.js
+++ b/test.js
@@ -389,6 +389,18 @@ var tests = [
     should: 'not crash on atrule without nodes',
     input: '@charset "utf-8";',
     expected: '@charset "utf-8";'
+  },
+  {
+    should: 'not crash on a rule without nodes',
+    input: (function() {
+      var inner = postcss.rule({ selector: '.b', ruleWithoutBody: true });
+      var outer = postcss.rule({ selector: '.a' }).push(inner);
+      var root = postcss.root().push(outer);
+      inner.nodes = undefined;
+      return root;
+    })(),
+    // postcss-less's stringify would honor `ruleWithoutBody` and omit the trailing `{}`
+    expected: ':local(.a) {\n    :local(.b) {}\n}'
   }
 
 ];


### PR DESCRIPTION
Hi! I'm working on adding experimental support in [ember-css-modules](https://github.com/salsify/ember-css-modules) for passing through other syntaxes like SCSS and Less.

As it turns out, the `postcss-less` parser represents Less-style mixins as rules with no child nodes, and this plugin would crash when it encountered such a rule when trying to iterate its children. This PR adds a simple guard against that case and corresponding test coverage.
