### PR TITLE
Whitelist files to be published to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-.gitignore
-node_modules/
-test.js
-.travis.yml
-coverage

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "travis": "npm run cover -- --report lcovonly",
     "prepublish": "npm prune && npm test",
     "publish-patch": "npm prune && npm test && npm version patch && git push && git push --tags && npm publish"
-  }
+  },
+  "files": [
+    "index.js"
+  ]
 }


### PR DESCRIPTION
This package has lots of files published to npm, including:
- .idea folder with 10 files
- .editorconfig
- .eslintrc
- .npmignore

Move from blacklist (`.npmignore`) to a whitelist (`files` in package.json) so it's not so easy to regress, and add the essential files there.
