### PR TITLE
fix(index): don't scope imported selector classes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -163,6 +163,10 @@ const composeExports = messages => {
 
 module.exports = postcss.plugin(plugin, (options = {}) => (css, result) => {
   const { icssImports, icssExports } = extractICSS(css);
+  const importAliases = {};
+  Object.keys(icssImports).forEach(filename => {
+    Object.assign(importAliases, icssImports[filename]);
+  });
   const generateScopedName =
     options.generateScopedName ||
     genericNames("[name]__[local]---[hash:base64:5]");
@@ -170,6 +174,9 @@ module.exports = postcss.plugin(plugin, (options = {}) => (css, result) => {
   const aliases = {};
   walkRules(css, rule => {
     const getAlias = name => {
+      if (importAliases[name]) {
+        return name;
+      }
       if (aliases[name]) {
         return aliases[name];
       }

--- a/test/test.js
+++ b/test/test.js
@@ -939,3 +939,47 @@ test("icss-value and icss-composed together", () => {
     ]
   });
 });
+
+test("does not replace imported values", () => {
+  return runCSS({
+    fixture: `
+      :import("~/lol.css") {
+        foo: __foo
+      }
+      .bar {
+        test: foo
+      }
+    `,
+    expected: `
+      :import('~/lol.css') {
+        foo: __foo
+      }
+      :export {
+        bar: __scope__bar
+      }
+      .__scope__bar {
+        test: foo
+      }
+    `
+  });
+});
+
+test("does not replaces imported selectors", () => {
+  return runCSS({
+    fixture: `
+      :import("~/lol.css") {
+        foo: __foo
+      }
+      .test .foo {}
+    `,
+    expected: `
+      :import('~/lol.css') {
+        foo: __foo
+      }
+      :export {
+        test: __scope__test
+      }
+      .__scope__test .foo {}
+    `
+  });
+});


### PR DESCRIPTION
This is part of an overall resolution to https://github.com/css-modules/icss/issues/12

I've got a PR ~coming to~ for https://github.com/webpack-contrib/css-loader that will enable this there as well. https://github.com/webpack-contrib/css-loader/pull/562